### PR TITLE
Huge cleanup

### DIFF
--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -10,7 +10,7 @@ pub struct Bucket (pub Vec<Fingerprint>);
 impl Bucket {
 
     pub fn new() -> Bucket {
-        Bucket(vec![])
+        Bucket(Vec::with_capacity(BUCKET_SIZE))
     }
 
     pub fn insert(&mut self, fp: Fingerprint) -> bool {
@@ -22,14 +22,15 @@ impl Bucket {
         }
     }
 
+    /// Deletes the given fingerprint from the bucket. Since the order inside
+    /// the bucket doesn't matter, we can use `swap_remove` to keep the runtime
+    /// in O(1).
     pub fn delete(&mut self, fp: Fingerprint) -> bool {
-        for i in 0..self.0.len() {
-            if self.0[i] == fp {
-                self.0.remove(i);
-                return true;
-            }
+        let pos = self.0.iter().position(|e| *e == fp);
+        match pos {
+            Some(index) => { self.0.swap_remove(index); true }
+            None => false
         }
-        false
     }
 
     pub fn get_fingerprint_index(&mut self, fp: Fingerprint) -> usize {

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -5,17 +5,24 @@ pub const BUCKET_SIZE: usize = 4;
 #[derive(PartialEq, Copy, Clone)]
 pub struct Fingerprint (pub u8);
 
-pub struct Bucket (pub Vec<Fingerprint>);
+/// Manages BUCKET_SIZE fingerprints at most.
+pub struct Bucket {
+    pub buffer: Vec<Fingerprint>,
+}
 
 impl Bucket {
-
+    /// Creates a new bucket with a pre-allocated buffer.
     pub fn new() -> Bucket {
-        Bucket(Vec::with_capacity(BUCKET_SIZE))
+        Bucket {
+            buffer: Vec::with_capacity(BUCKET_SIZE)
+        }
     }
 
+    /// Inserts the fingerprint into the buffer if the buffer is not full. This
+    /// Operation will be O(1), since the buffer was pre-allocated.
     pub fn insert(&mut self, fp: Fingerprint) -> bool {
-        if self.0.len() < BUCKET_SIZE {
-            self.0.push(fp);
+        if self.buffer.len() < BUCKET_SIZE {
+            self.buffer.push(fp);
             true
         } else {
             false
@@ -26,19 +33,14 @@ impl Bucket {
     /// the bucket doesn't matter, we can use `swap_remove` to keep the runtime
     /// in O(1).
     pub fn delete(&mut self, fp: Fingerprint) -> bool {
-        let pos = self.0.iter().position(|e| *e == fp);
-        match pos {
-            Some(index) => { self.0.swap_remove(index); true }
+        match self.get_fingerprint_index(fp) {
+            Some(index) => { self.buffer.swap_remove(index); true }
             None => false
         }
     }
 
-    pub fn get_fingerprint_index(&mut self, fp: Fingerprint) -> usize {
-        for i in 0..self.0.len() {
-            if self.0[i] == fp {
-                return i;
-            }
-        }
-        BUCKET_SIZE + 1
+    /// Returns the index of the given fingerprint, if its found.
+    pub fn get_fingerprint_index(&mut self, fp: Fingerprint) -> Option<usize> {
+        self.buffer.iter().position(|e| *e == fp)
     }
 }

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -30,8 +30,8 @@ impl Bucket {
     }
 
     /// Deletes the given fingerprint from the bucket. Since the order inside
-    /// the bucket doesn't matter, we can use `swap_remove` to keep the runtime
-    /// in O(1).
+    /// the bucket doesn't matter, we can use `swap_remove` to make the
+    /// deletion O(1). Finding element still needs O(n).
     pub fn delete(&mut self, fp: Fingerprint) -> bool {
         match self.get_fingerprint_index(fp) {
             Some(index) => { self.buffer.swap_remove(index); true }
@@ -39,7 +39,7 @@ impl Bucket {
         }
     }
 
-    /// Returns the index of the given fingerprint, if its found.
+    /// Returns the index of the given fingerprint, if its found. O(n)
     pub fn get_fingerprint_index(&mut self, fp: Fingerprint) -> Option<usize> {
         self.buffer.iter().position(|e| *e == fp)
     }

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -10,15 +10,16 @@ pub struct Bucket (pub Vec<Fingerprint>);
 impl Bucket {
 
     pub fn new() -> Bucket {
-        return Bucket(vec![]);
+        Bucket(vec![])
     }
 
     pub fn insert(&mut self, fp: Fingerprint) -> bool {
         if self.0.len() < BUCKET_SIZE {
             self.0.push(fp);
-            return true;
-        } 
-        return false;
+            true
+        } else {
+            false
+        }
     }
 
     pub fn delete(&mut self, fp: Fingerprint) -> bool {
@@ -27,8 +28,8 @@ impl Bucket {
                 self.0.remove(i);
                 return true;
             }
-        } 
-        return false;
+        }
+        false
     }
 
     pub fn get_fingerprint_index(&mut self, fp: Fingerprint) -> usize {
@@ -36,7 +37,7 @@ impl Bucket {
             if self.0[i] == fp {
                 return i;
             }
-        } 
-        return BUCKET_SIZE + 1;
+        }
+        BUCKET_SIZE + 1
     }
 }

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -6,6 +6,7 @@ pub const BUCKET_SIZE: usize = 4;
 pub struct Fingerprint (pub u8);
 
 /// Manages BUCKET_SIZE fingerprints at most.
+#[derive(Clone)]
 pub struct Bucket {
     pub buffer: Vec<Fingerprint>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ impl CuckooFilter {
         let len = self.buckets.len();
         let b1 = self.buckets[i1%len].get_fingerprint_index(fp);
         let b2 = self.buckets[i2%len].get_fingerprint_index(fp);
-        return b1 < BUCKET_SIZE || b2 < BUCKET_SIZE;
+        b1.or(b2).is_some()
     }
 
     /**
@@ -142,8 +142,8 @@ impl CuckooFilter {
             let j = rand::thread_rng().gen_range(0.0, BUCKET_SIZE as f64) as usize;
             let newfp = fp;
             let len = self.buckets.len();
-            fp = self.buckets[i%len].0[j];
-            self.buckets[i%len].0[j] = newfp;
+            fp = self.buckets[i%len].buffer[j];
+            self.buckets[i%len].buffer[j] = newfp;
             i = get_alt_index(&mut fp, i);
             if self.put(fp, i) {
                 return true;

--- a/src/util.rs
+++ b/src/util.rs
@@ -36,18 +36,6 @@ pub fn get_fai(data: &[u8]) -> FaI {
     }
 }
 
-pub fn get_next_pow_2(mut n: u64) -> u64 {
-    n-=1;
-    n |= n >> 1;
-    n |= n >> 2;
-    n |= n >> 4;
-    n |= n >> 8;
-    n |= n >> 16;
-    n |= n >> 32;
-    n+=1;
-    return n;
-}
-
 #[test]
 fn test_fp_and_index() {
     let data = &"seif".as_bytes();


### PR DESCRIPTION
Like I said on reddit: Here is a huge cleanup/refactor to make everything more rusty/idiomatic. I also made a list of things I did to make it more rusty.

There is still a lot of cleanup necessary, but the hashing stuff depends on an external crate which needs cleanup too, so I will probably continue there. If there are some things I missed or things you (Rust programmer) are not happy with, just comment here.

So here is the list:

1. `return`s: In Rust we rarely use the keyword `return`, since the last expression in the function is returned by default. It's only neccessary for early returns.
2. Self written loops: In Rust we rarely write manual loops. Counting up an index is not really neccessary in most cases. Iterators can solve most of our problems in an easy and nice way ;)
3. Tuple-Structs: They are great for creating new types out of existing ones. But as stated [here](https://doc.rust-lang.org/book/structs.html#tuple-structs): "It is almost always better to use a struct than a tuple struct."
4. Typical method names: It's often useful to use typical method names in order to make the user feel familiar with your library from the beginning. The very important `Vec` from std uses `new` without parameters and `with_capacity` with a given capacity.
5. Destructuring is always helpful to get shorter code (also DRY)
6. Mutable variables should be avoided: If it's possible its nice to have immutable variables everywhere. I changed the calculation of `capacity` in `with_capacity` to match that pattern. Could be done differently, but immutable is nice.
