### PR TITLE
Use drastically fewer allocations, add benchmarks, allow different hashers to be used, and enable insertion of all Hashable items.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,8 @@ default = []
 dev = ["clippy"]
 
 [dependencies]
-farmhash = "1.1.2"
 byteorder = "0.3.11"
 rand = "0.3"
 clippy = {version = "0.0.6", optional = true}
+fnv = {version = "1.0.0", optional = true}
+farmhash = {version = "1.1.2", optional = true}

--- a/README.md
+++ b/README.md
@@ -18,28 +18,24 @@ extern crate cuckoofilter;
 
 let value: &str = "hello world";
 
-// Create cuckoo filter with max capacity of 1000000 items
-let cf = cuckoofilter::new(1000000);
+// Create cuckoo filter with default max capacity of 1000000 items
+let mut cf = cuckoofilter::new();
 
 // Add data to the filter
-let success = cf.add(&value.as_bytes());
+let success = cf.add(value);
 // success ==> true
 
 // Lookup if data is in the filter
-let success = cf.lookup(&value.as_bytes());
+let success = cf.contains(value);
 // success ==> true
 
 // Test and add to the filter (if data does not exists then add)
-let success = cf.test_and_add(&value.as_bytes());
+let success = cf.test_and_add(value);
 // success ==> false
 
 // Remove data from the filter.
-let success = cf.delete(&value.as_bytes());
+let success = cf.delete(value);
 // success ==> true
-
-// Lookup if data is in the filter
-let success = cf.lookup(&value.as_bytes());
-// success ==> false
 ```
 
 

--- a/benches/bench_lib.rs
+++ b/benches/bench_lib.rs
@@ -1,0 +1,71 @@
+#![feature(test)]
+
+extern crate cuckoofilter;
+extern crate test;
+extern crate rand;
+#[cfg(feature = "fnv")]
+extern crate fnv;
+#[cfg(feature = "farmhash")]
+extern crate farmhash;
+
+use self::cuckoofilter::*;
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::Path;
+use std::error::Error;
+
+fn get_words() -> String {
+  let path = Path::new("/usr/share/dict/words");
+  let display = path.display();
+
+  // Open the path in read-only mode, returns `io::Result<File>`
+  let mut file = match File::open(&path) {
+    // The `description` method of `io::Error` returns a string that
+    // describes the error
+    Err(why) => panic!("couldn't open {}: {}", display,
+                                               Error::description(&why)),
+    Ok(file) => file,
+  };
+
+  let mut contents = String::new();
+  if let Err(why) = file.read_to_string(&mut contents) {
+    panic!("couldn't read {}: {}", display, Error::description(&why));
+  }
+  contents
+}
+
+fn perform_insertions<H: std::hash::Hasher + Default>(b: &mut test::Bencher) {
+  let contents = get_words();
+  let split: Vec<&str> = contents.split("\n").take(1000).collect();
+  let mut cf = CuckooFilter::<H>::with_capacity((split.len() * 2) as u64);
+
+  b.iter(|| {
+    for s in &split {
+      test::black_box(cf.test_and_add(s));
+    }
+  });
+}
+
+#[bench]
+fn bench_new(b: &mut test::Bencher) {
+  b.iter(|| {
+    test::black_box(CuckooFilter::new());
+  });
+}
+
+#[cfg(feature = "farmhash")]
+#[bench]
+fn bench_insertion_farmhash(b: &mut test::Bencher) {
+  perform_insertions::<farmhash::FarmHasher>(b);
+}
+
+#[cfg(feature = "fnv")]
+#[bench]
+fn bench_insertion_fnv(b: &mut test::Bencher) {
+  perform_insertions::<fnv::FnvHasher>(b);
+}
+
+#[bench]
+fn bench_insertion_sip(b: &mut test::Bencher) {
+  perform_insertions::<std::hash::SipHasher>(b);
+}

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -1,5 +1,5 @@
-pub const FINGERPRINT_SIZE: usize = 2;
-pub const BUCKET_SIZE: usize = 8;
+pub const FINGERPRINT_SIZE: usize = 1;
+pub const BUCKET_SIZE: usize = 4;
 const EMPTY_FINGERPRINT_DATA: [u8; FINGERPRINT_SIZE] = [100; FINGERPRINT_SIZE];
 
 // Fingerprint Size is 1 byte so lets remove the Vec

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -1,46 +1,74 @@
-//pub const FINGERPRINT_SIZE: usize = 1;
-pub const BUCKET_SIZE: usize = 4;
+pub const FINGERPRINT_SIZE: usize = 2;
+pub const BUCKET_SIZE: usize = 8;
+const EMPTY_FINGERPRINT_DATA: [u8; FINGERPRINT_SIZE] = [100; FINGERPRINT_SIZE];
 
 // Fingerprint Size is 1 byte so lets remove the Vec
-#[derive(PartialEq, Copy, Clone)]
-pub struct Fingerprint (pub u8);
+#[derive(PartialEq, Copy, Clone, Hash)]
+pub struct Fingerprint {
+  data: [u8; FINGERPRINT_SIZE]
+}
+
+impl Fingerprint {
+  /// Attempts to create a new Fingerprint based on the given
+  /// number. If the created Fingerprint would be equal to the
+  /// empty Fingerprint, None is returned.
+  pub fn from_usize(mut n: usize) -> Option<Fingerprint> {
+    let mut data = [0; FINGERPRINT_SIZE];
+    for i in 0..FINGERPRINT_SIZE {
+      data[i] = (n & 0xff) as u8;
+      n >>= 8;
+    }
+    let result = Fingerprint{ data: data };
+    if result.is_empty() { None }
+    else { Some(result) }
+  }
+
+  /// Returns the empty Fingerprint.
+  pub fn empty() -> Fingerprint {
+    Fingerprint { data: EMPTY_FINGERPRINT_DATA }
+  }
+
+  /// Checks if this is the empty Fingerprint.
+  pub fn is_empty(&self) -> bool {
+    self.data == EMPTY_FINGERPRINT_DATA
+  }
+}
 
 /// Manages BUCKET_SIZE fingerprints at most.
 #[derive(Clone)]
 pub struct Bucket {
-    pub buffer: Vec<Fingerprint>,
+    pub buffer: [Fingerprint; BUCKET_SIZE]
 }
 
 impl Bucket {
     /// Creates a new bucket with a pre-allocated buffer.
     pub fn new() -> Bucket {
         Bucket {
-            buffer: Vec::with_capacity(BUCKET_SIZE)
+            buffer: [Fingerprint::empty(); BUCKET_SIZE]
         }
     }
 
     /// Inserts the fingerprint into the buffer if the buffer is not full. This
-    /// Operation will be O(1), since the buffer was pre-allocated.
+    /// operation is O(1).
     pub fn insert(&mut self, fp: Fingerprint) -> bool {
-        if self.buffer.len() < BUCKET_SIZE {
-            self.buffer.push(fp);
-            true
-        } else {
-            false
+      for entry in self.buffer.iter_mut() {
+        if entry.is_empty() {
+          *entry = fp;
+          return true;
         }
+      }
+      false
     }
 
-    /// Deletes the given fingerprint from the bucket. Since the order inside
-    /// the bucket doesn't matter, we can use `swap_remove` to make the
-    /// deletion O(1). Finding element still needs O(n).
+    /// Deletes the given fingerprint from the bucket. This operation is O(1).
     pub fn delete(&mut self, fp: Fingerprint) -> bool {
         match self.get_fingerprint_index(fp) {
-            Some(index) => { self.buffer.swap_remove(index); true }
+            Some(index) => { self.buffer[index] = Fingerprint::empty(); true }
             None => false
         }
     }
 
-    /// Returns the index of the given fingerprint, if its found. O(n)
+    /// Returns the index of the given fingerprint, if its found. O(1)
     pub fn get_fingerprint_index(&mut self, fp: Fingerprint) -> Option<usize> {
         self.buffer.iter().position(|e| *e == fp)
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,22 +1,5 @@
-use std::hash::{Hasher, Hash, hash};
-use ::byteorder::{BigEndian, WriteBytesExt, ReadBytesExt};
+use std::hash::{Hasher, Hash};
 use ::bucket::{Fingerprint};
-
-fn get_hash<T: ?Sized + Hash, H: Hasher + Default>(data: &T) -> [u8; 4] {
-  let mut result = [0; 4];
-  {
-    let mut hasher = <H as Default>::default();
-    data.hash(&mut hasher);
-    let _ = (&mut result[..]).write_u32::<BigEndian>(hasher.finish() as u32);
-  }
-  result
-}
-
-pub fn get_alt_index<H: Hasher + Default>(fp: &Fingerprint, i: usize) -> usize {
-    let hash = get_hash::<_, H>(&[fp.0]);
-    let alt_i = (&hash[..]).read_u32::<BigEndian>().unwrap() as usize;
-    (i ^ alt_i) as usize
-}
 
 pub struct FaI {
     pub fp: Fingerprint,
@@ -24,26 +7,59 @@ pub struct FaI {
     pub i2: usize
 }
 
-pub fn get_fai<T: ?Sized + Hash, H: Hasher + Default>(data: &T) -> FaI {
-    let hash = get_hash::<_, H>(data);
-    let f = Fingerprint(hash[0]);
-    let i1 = (&hash[..]).read_u32::<BigEndian>().unwrap() as usize;
-    let i2 = get_alt_index::<H>(&f, i1);
-    FaI {
-        fp: f, i1: i1, i2: i2
+pub fn get_alt_index<H: Hasher + Default>(fp: Fingerprint, index: usize) -> usize {
+  let mut hasher = <H as Default>::default();
+  fp.hash(&mut hasher);
+  hasher.finish() as usize ^ index
+}
+
+impl FaI {
+  fn from_data<T: ?Sized + Hash, H: Hasher + Default>(data: &T) -> FaI {
+    let i1;
+    let fp;
+    let mut n = 1;
+    loop {
+      let mut hasher = <H as Default>::default();
+      for _ in 0..n {
+        data.hash(&mut hasher);
+      }
+      let hash = hasher.finish() as usize;
+      if let Some(val) = Fingerprint::from_usize(hash) {
+        i1 = hash;
+        fp = val;
+        break;
+      }
+      n += 1;
     }
+    let i2 = get_alt_index::<H>(fp, i1);
+
+    FaI { fp: fp, i1: i1, i2: i2 }
+  }
+
+  pub fn random_index<R: ::rand::Rng>(&self, r: &mut R) -> usize {
+    if r.gen() {
+      self.i1
+    } else {
+      self.i2
+    }
+  }
+}
+
+pub fn get_fai<T: ?Sized + Hash, H: Hasher + Default>(data: &T) -> FaI {
+    FaI::from_data::<_, H>(data)
 }
 
 #[test]
 fn test_fp_and_index() {
-    let data = &"seif".as_bytes();
-    let fai = get_fai::<_, ::farmhash::FarmHasher>(data);
-    let fp = &fai.fp;
-    let i1 = fai.i1;
-    let i2 = fai.i2;
-    let i11 = get_alt_index::<::farmhash::FarmHasher>(fp, i2);
-    assert_eq!(i11, i1);
+  use std::hash::SipHasher;
+  let data = "seif";
+  let fai = get_fai::<_, SipHasher>(data);
+  let fp = fai.fp;
+  let i1 = fai.i1;
+  let i2 = fai.i2;
+  let i11 = get_alt_index::<SipHasher>(fp, i2);
+  assert_eq!(i11, i1);
 
-    let i22 = get_alt_index::<::farmhash::FarmHasher>(fp, i11);
-    assert_eq!(i22, i2);
+  let i22 = get_alt_index::<SipHasher>(fp, i11);
+  assert_eq!(i22, i2);
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,21 +1,20 @@
-extern crate farmhash;
-extern crate byteorder;
+use std::hash::{Hasher, Hash, hash};
+use ::byteorder::{BigEndian, WriteBytesExt, ReadBytesExt};
+use ::bucket::{Fingerprint};
 
-use std::io::Cursor;
-use self::byteorder::{BigEndian, WriteBytesExt, ReadBytesExt};
-use bucket::{Fingerprint};
-
-pub fn get_hash(data: &[u8]) -> Vec<u8> {
-    let hash32 = farmhash::hash32(data);
-    let mut hash = vec![];
-    hash.write_u32::<BigEndian>(hash32).unwrap();
-    hash
+fn get_hash<T: ?Sized + Hash, H: Hasher + Default>(data: &T) -> [u8; 4] {
+  let mut result = [0; 4];
+  {
+    let mut hasher = <H as Default>::default();
+    data.hash(&mut hasher);
+    let _ = (&mut result[..]).write_u32::<BigEndian>(hasher.finish() as u32);
+  }
+  result
 }
 
-pub fn get_alt_index(fp: &Fingerprint, i: usize) -> usize {
-    let hash = get_hash(&[fp.0]);
-    let mut rdr = Cursor::new(hash);
-    let alt_i = rdr.read_u32::<BigEndian>().unwrap() as usize;
+pub fn get_alt_index<H: Hasher + Default>(fp: &Fingerprint, i: usize) -> usize {
+    let hash = get_hash::<_, H>(&[fp.0]);
+    let alt_i = (&hash[..]).read_u32::<BigEndian>().unwrap() as usize;
     (i ^ alt_i) as usize
 }
 
@@ -25,12 +24,11 @@ pub struct FaI {
     pub i2: usize
 }
 
-pub fn get_fai(data: &[u8]) -> FaI {
-    let hash = get_hash(data);
+pub fn get_fai<T: ?Sized + Hash, H: Hasher + Default>(data: &T) -> FaI {
+    let hash = get_hash::<_, H>(data);
     let f = Fingerprint(hash[0]);
-    let mut rdr = Cursor::new(hash);
-    let i1 = rdr.read_u32::<BigEndian>().unwrap() as usize;
-    let i2 = get_alt_index(&f, i1);
+    let i1 = (&hash[..]).read_u32::<BigEndian>().unwrap() as usize;
+    let i2 = get_alt_index::<H>(&f, i1);
     FaI {
         fp: f, i1: i1, i2: i2
     }
@@ -39,13 +37,13 @@ pub fn get_fai(data: &[u8]) -> FaI {
 #[test]
 fn test_fp_and_index() {
     let data = &"seif".as_bytes();
-    let fai = get_fai(data);
+    let fai = get_fai::<_, ::farmhash::FarmHasher>(data);
     let fp = &fai.fp;
     let i1 = fai.i1;
     let i2 = fai.i2;
-    let i11 = get_alt_index(fp, i2);
+    let i11 = get_alt_index::<::farmhash::FarmHasher>(fp, i2);
     assert_eq!(i11, i1);
 
-    let i22 = get_alt_index(fp, i11);
+    let i22 = get_alt_index::<::farmhash::FarmHasher>(fp, i11);
     assert_eq!(i22, i2);
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -9,14 +9,14 @@ pub fn get_hash(data: &[u8]) -> Vec<u8> {
     let hash32 = farmhash::hash32(data);
     let mut hash = vec![];
     hash.write_u32::<BigEndian>(hash32).unwrap();
-    return hash;
+    hash
 }
 
 pub fn get_alt_index(fp: &Fingerprint, i: usize) -> usize {
     let hash = get_hash(&[fp.0]);
     let mut rdr = Cursor::new(hash);
     let alt_i = rdr.read_u32::<BigEndian>().unwrap() as usize;
-    return (i ^ alt_i) as usize;
+    (i ^ alt_i) as usize
 }
 
 pub struct FaI {
@@ -31,7 +31,7 @@ pub fn get_fai(data: &[u8]) -> FaI {
     let mut rdr = Cursor::new(hash);
     let i1 = rdr.read_u32::<BigEndian>().unwrap() as usize;
     let i2 = get_alt_index(&f, i1);
-    return FaI {
+    FaI {
         fp: f, i1: i1, i2: i2
     }
 }

--- a/tests/test_lib.rs
+++ b/tests/test_lib.rs
@@ -1,4 +1,7 @@
+#![feature(test)]
+
 extern crate cuckoofilter;
+extern crate test;
 
 use self::cuckoofilter::*;
 use std::fs::File;
@@ -6,37 +9,44 @@ use std::io::prelude::*;
 use std::path::Path;
 use std::error::Error;
 
+fn get_words() -> String {
+  let path = Path::new("/usr/share/dict/words");
+  let display = path.display();
+
+  // Open the path in read-only mode, returns `io::Result<File>`
+  let mut file = match File::open(&path) {
+    // The `description` method of `io::Error` returns a string that
+    // describes the error
+    Err(why) => panic!("couldn't open {}: {}", display,
+                                               Error::description(&why)),
+    Ok(file) => file,
+  };
+
+  let mut contents = String::new();
+  if let Err(why) = file.read_to_string(&mut contents) {
+    panic!("couldn't read {}: {}", display, Error::description(&why));
+  }
+  contents
+}
+
 #[test]
 fn test_insertion() {
-    let path = Path::new("/usr/share/dict/web2");
-    let display = path.display();
+  let contents = get_words();
+  let split: Vec<&str> = contents.split("\n").collect();
 
-    // Open the path in read-only mode, returns `io::Result<File>`
-    let mut file = match File::open(&path) {
-        // The `description` method of `io::Error` returns a string that
-        // describes the error
-        Err(why) => panic!("couldn't open {}: {}", display,
-                                                   Error::description(&why)),
-        Ok(file) => file,
-    };
+  let mut cf = CuckooFilter::new();
+  let mut insertions = 0;
+  for s in &split {
+      if cf.test_and_add(s) {
+        insertions += 1;
+      }
+  }
+  assert_eq!(cf.len(), insertions);
+  assert_eq!(cf.len(), split.len() as u64);
 
-    let mut web2 = String::new();
-    match file.read_to_string(&mut web2) {
-        Err(why) => panic!("couldn't read {}: {}", display,
-                                                   Error::description(&why)),
-        Ok(_) => {},
-    }
-
-    let mut split: Vec<&str> = web2.split("\n").collect();
-
-    let mut cf = CuckooFilter::new();
-    for s in &mut split {
-        cf.test_and_add(&s.as_bytes());
-    }
-    assert_eq!(cf.len(), 235033);
-
-    for s in &mut split {
-        cf.delete(&s.as_bytes());
-    }
-    assert_eq!(cf.len(), 0);
+  for s in &split {
+      cf.delete(s);
+  }
+  assert_eq!(cf.len(), 0);
+  assert!(cf.is_empty());
 }


### PR DESCRIPTION
I played around with your code a bit today. I decided to address issue #2, which was fun. While I was at it I also modified CuckooFilter to be used with different Hashers. Then I noticed that each individual bucket allocates its own vector which seemed like the wrong thing to do in a data structure that is supposed to use little memory, so I removed those allocations by chosing a magic 'empty' Fingerprint value (currently the fingerprint where all bytes contain the value '100').

To compare FarmHash with the `std::hash::SipHasher` I added some benchmarks, and or irc the the [fnv](https://github.com/servo/rust-fnv) hasher was recommended so I threw that one in as well. It looks like FarmHash is the slowest, so I made `SipHasher` the default. The benchmarks can be admired by running `cargo bench --features "fnv farmhash"`.

My machine did not have the `/usr/share/dict/web2` so I changed the test function to use `/usr/share/dict/words` instead. It looks like there are a *lot* of collisions when inserting the lines of this file into a CuckooFilter of the default size.