### PR TITLE
Removing &mut references to self in the contains `method` of CuckooFilter and 'get_fingerprint_index' of Bucket

### DIFF
--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -64,7 +64,7 @@ impl Bucket {
     }
 
     /// Returns the index of the given fingerprint, if its found. O(1)
-    pub fn get_fingerprint_index(&mut self, fp: Fingerprint) -> Option<usize> {
+    pub fn get_fingerprint_index(&self, fp: Fingerprint) -> Option<usize> {
         self.buffer.iter().position(|e| *e == fp)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ impl<H> CuckooFilter<H>
     }
 
     /// Checks if `data` is in the filter.
-    pub fn contains<T: ?Sized + Hash>(&mut self, data: &T) -> bool {
+    pub fn contains<T: ?Sized + Hash>(&self, data: &T) -> bool {
         let FaI { fp, i1, i2 } = get_fai::<T, H>(data);
         let len = self.buckets.len();
         self.buckets[i1%len].get_fingerprint_index(fp).or(


### PR DESCRIPTION
Neither of these methods need to modify self and so should not take a mutable reference to it.