### PR TITLE
Add false positive rate integration test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,10 @@ impl<H> CuckooFilter<H>
     }
 
     /// Adds `data` to the filter. Returns true if the insertion was successful.
+    /// Note that while you can put any hashable type in the same filter, beware
+    /// for side effects like that the same number can have diferent hashes
+    /// depending on the type.
+    /// So for the filter, 4711i64 isn't the same as 4711u64.
     pub fn add<T: ?Sized + Hash>(&mut self, data: &T) -> bool {
         let fai = get_fai::<T, H>(data);
         if self.put(fai.fp, fai.i1) || self.put(fai.fp, fai.i2) {

--- a/tests/false_positive_rate.rs
+++ b/tests/false_positive_rate.rs
@@ -1,0 +1,47 @@
+extern crate cuckoofilter;
+use cuckoofilter::CuckooFilter;
+use std::collections::hash_map::DefaultHasher;
+
+// Modelled after
+// https://github.com/efficient/cuckoofilter/blob/master/example/test.cc
+// to make test setup and results comparable.
+
+#[test]
+fn false_positive_rate() {
+    let total_items = 1_000_000;
+
+    let mut filter = CuckooFilter::<DefaultHasher>::with_capacity(total_items);
+
+    let mut num_inserted: u64 = 0;
+    // We might not be able to get all items in, but still there should be enough
+    // so we can just use what has fit in and continue with the test.
+    for i in 0..total_items {
+        if filter.add(&i) {
+            num_inserted += 1;
+        } else {
+            break;
+        }
+    }
+
+    // The range 0..num_inserted are all known to be in the filter.
+    // The filter shouldn't return false negatives, and therefore they should all be contained.
+    for i in 0..num_inserted {
+        assert!(filter.contains(&i));
+    }
+
+    // The range total_items..(2 * total_items) are all known *not* to be in the filter.
+    // Every element for which the filter claims that it is contained is therefore a false positive.
+    let mut false_queries: u64 = 0;
+    for i in total_items..(2 * total_items) {
+        if filter.contains(&i) {
+            false_queries += 1;
+        }
+    }
+    let false_positive_rate = (false_queries as f64) / (total_items as f64);
+
+    println!("elements inserted: {}", num_inserted);
+    println!("memory usage: {:.2}KiB", (filter.memory_usage() as f64) / 1024.0);
+    println!("false positive rate: {}%", 100.0 * false_positive_rate);
+    // ratio should be around 0.024, round up to 0.03 to accomodate for random fluctuation
+    assert!(false_positive_rate < 0.03);
+}


### PR DESCRIPTION
and document the filter's untypedness, took quite some time when writing the test until I got what's going wrong.

On 10 years old laptop, the test suite now takes 25 seconds to run due to the one million elements, which is long, but I guess it's good to have a test which really fills a large filter and sees whether everything is still all-right, and it also reduces the fluctuation in the false positive rate. Also, it's probably way faster on something more modern.

@seiflotfy is this acceptable?