### PR TITLE
Make len & with_capacity usize instead of u64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - add() now returns Result<(), CuckooError> instead of a bool, and returns a NotEnoughSpaceError instead of panicking
   when insertion fails.
 - len() now returns usize instead of u64 to match std's data structures' len() functions.
+- with_capacity() now takes an usize instead of an u64 to match std's data structures' with_capacity() functions.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - add() now returns Result<(), CuckooError> instead of a bool, and returns a NotEnoughSpaceError instead of panicking
   when insertion fails.
+- len() now returns usize instead of u64 to match std's data structures' len() functions.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/benches/bench_lib.rs
+++ b/benches/bench_lib.rs
@@ -36,7 +36,7 @@ fn get_words() -> String {
 fn perform_insertions<H: std::hash::Hasher + Default>(b: &mut test::Bencher) {
     let contents = get_words();
     let split: Vec<&str> = contents.split("\n").take(1000).collect();
-    let mut cf = CuckooFilter::<H>::with_capacity((split.len() * 2) as u64);
+    let mut cf = CuckooFilter::<H>::with_capacity(split.len() * 2);
 
     b.iter(|| {
         for s in &split {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,12 +78,12 @@ impl StdError  for CuckooError {
 /// }
 ///
 /// assert_eq!(insertions, words.len());
-/// assert_eq!(cf.len(), words.len() as u64);
+/// assert_eq!(cf.len(), words.len());
 ///
 /// // Re-add the first element.
 /// cf.add(words[0]);
 ///
-/// assert_eq!(cf.len(), words.len() as u64 + 1);
+/// assert_eq!(cf.len(), words.len() + 1);
 ///
 /// for s in &words {
 ///     cf.delete(s);
@@ -100,7 +100,7 @@ impl StdError  for CuckooError {
 /// ```
 pub struct CuckooFilter<H> {
     buckets: Box<[Bucket]>,
-    len: u64,
+    len: usize,
     _hasher: std::marker::PhantomData<H>,
 }
 
@@ -194,7 +194,7 @@ impl<H> CuckooFilter<H>
     }
 
     /// Number of items in the filter.
-    pub fn len(&self) -> u64 {
+    pub fn len(&self) -> usize {
         self.len
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ use std::error::Error as StdError;
 pub const MAX_REBUCKET: u32 = 500;
 
 /// The default number of buckets.
-pub const DEFAULT_CAPACITY: u64 = (1 << 20) - 1;
+pub const DEFAULT_CAPACITY: usize = (1 << 20) - 1;
 
 #[derive(Debug)]
 pub enum CuckooError {
@@ -121,15 +121,15 @@ impl<H> CuckooFilter<H>
     where H: Hasher + Default
 {
     /// Constructs a Cuckoo Filter with a given max capacity
-    pub fn with_capacity(cap: u64) -> CuckooFilter<H> {
-        let capacity = match cap.next_power_of_two() / BUCKET_SIZE as u64 {
+    pub fn with_capacity(cap: usize) -> CuckooFilter<H> {
+        let capacity = match cap.next_power_of_two() / BUCKET_SIZE {
             0 => 1,
             cap => cap,
         };
 
         CuckooFilter {
             buckets: repeat(Bucket::new())
-                .take(capacity as usize)
+                .take(capacity)
                 .collect::<Vec<_>>()
                 .into_boxed_slice(),
             len: 0,


### PR DESCRIPTION
to match std's data structures' len() functions.
The rationale behind it seems to be that if the maximum value is proportional to the
maximum memory size, it should be an usize.

I could not find exact agreements on when to use usize and when not, though. This would have the effect of allowing only 2^32 items on 32bit systems, where previously 2^32 * BUCKET_SIZE (so 2^36) items were allowed until `CuckooFilter.buffer` would get an overflow.

My main motivation is that it just felt weird when using the library that `len()` returns u64, in contrast to all other len methods I've encountered so far.