### PR TITLE
Add autogenerated C ABI crate via cbindgen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [v0.4.0] - Unreleased
 ### Added
 - `ExportedCuckooFilter` adds the ability to serialize the memory map of a `CuckooFilter` via Serde; reducing communication overhead between nodes for example, or the ability to store the current state on disk for retrieval at a later time.
+- Added a C interface for embedding this crate into other languages.
+  The interface is an additional crate, located in the cabi/ subfolder.
 ### Changed
 - add() now returns Result<(), CuckooError> instead of a bool, and returns a NotEnoughSpaceError instead of panicking
   when insertion fails.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,14 @@ let success = cf.delete(value);
 // success ==> true
 ```
 
+## C Interface
+This crate has a C interface for embedding it into other languages than Rust.
+See the [C Interface Documentation](https://docs.rs/cuckoofilter_cabi) for more details.
+
 
 ## Notes & TODOs
 * This implementation uses a a static bucket size of 4 fingerprints and a fingerprint size of 1 byte based on my understanding of an optimal bucket/fingerprint/size ratio from the aforementioned paper.
 * When the filter returns `NotEnoughSpace`, the element given is actually added to the filter, but some random *other*
   element gets removed. This could be improved by implementing a single-item eviction cache for that removed item.
+* There are no high-level bindings for other languages than C.
+  One could add them e.g. for python using [milksnake](https://github.com/getsentry/milksnake).

--- a/cabi/.gitignore
+++ b/cabi/.gitignore
@@ -1,0 +1,1 @@
+tests/build

--- a/cabi/Cargo.toml
+++ b/cabi/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "cuckoofilter-cabi"
+version = "0.4.0"
+license = "MIT"
+authors = [
+    "Florian Jacob <accounts+git@florianjacob.de>"
+]
+homepage = "http://geekyogre.com"
+repository = "https://github.com/seiflotfy/rust-cuckoofilter"
+description = """
+C interface wrapper for cuckoofilter, a library for
+the Bloom filter replacement for approximated set-membership queries.
+"""
+keywords = ["bloomfilter", "cuckoohashing", "cuckoofilter"]
+
+build = "build.rs"
+
+[profile.release]
+lto = true
+
+[dependencies]
+cuckoofilter = { version = "0.4", path = "../" }
+
+[build-dependencies]
+cbindgen = "0.5"
+
+[lib]
+# foreign programs can link against cdylib or staticlib to use rust-cuckoofilter's C API
+crate-type = ["cdylib", "staticlib"]

--- a/cabi/Makefile
+++ b/cabi/Makefile
@@ -1,0 +1,17 @@
+PREFIX = /usr/local
+
+HEADER = rcf_cuckoofilter.h
+LIBS = libcuckoofilter_cabi.a libcuckoofilter_cabi.so
+
+error:
+	@echo "Please use 'cargo build --release' for building, the Makefile is for installation only (via 'make install')."
+
+.PHONY: install
+install:
+	install -D -m 0755 $(addprefix target/include/,$(HEADER)) -t $(DESTDIR)$(PREFIX)/include
+	install -D -m 0755 $(addprefix target/release/,$(LIBS)) -t $(DESTDIR)$(PREFIX)/lib
+
+.PHONY: uninstall
+uninstall:
+	rm -f $(DESTDIR)$(PREFIX)/lib/$(LIBS)
+	rm -f $(DESTDIR)$(PREFIX)/include/$(HEADER)

--- a/cabi/build.rs
+++ b/cabi/build.rs
@@ -1,0 +1,16 @@
+extern crate cbindgen;
+
+use std::env;
+
+fn main() {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    cbindgen::Builder::new()
+      .with_crate(crate_dir)
+      .with_language(cbindgen::Language::C)
+      .with_parse_deps(true)
+      .with_parse_include(&["cuckoofilter"])
+      .generate()
+      .expect("Unable to generate bindings")
+      .write_to_file("target/include/rcf_cuckoofilter.h");
+}

--- a/cabi/src/lib.rs
+++ b/cabi/src/lib.rs
@@ -1,0 +1,184 @@
+//! A C interface for the [cuckoofilter crate].
+//!
+//! You can use this crate to use the `cuckoofilter` crate from C/C++, or almost any other
+//! language. There only needs to be a way to call foreign C functions, like in python or ruby.
+//!
+//! **Note**: For other languages, you'd probably want to add a language-specific layer on top of
+//! this, e.g. using [milksnake] for python. Contributions welcome!
+//!
+//! # Build Setup
+//!
+//! You need to integrate this crate in your build system somehow, how you do this depends on your
+//! specific build system. You can e.g. use a local checkout of the [cuckoofilter crate]:
+//!
+//! ```bash
+//! git clone https://github.com/seiflotfy/rust-cuckoofilter
+//! cd rust-cuckoofilter/cabi
+//! cargo build --release
+//! ```
+//!
+//! Then, put the generated file `cabi/target/include/rcf_cuckoofilter.h` on your compiler's
+//! include path and link against either `cabi/target/release/libcuckoofilter_cabi.a` or
+//! `cabi/target/release/libcuckoofilter_cabi.so`, depending on whether you want static or dynamic
+//! linking. Alternatively, use the provided Makefile via `sudo make install` to install the header
+//! and libraries system-wide. You can see the `tests` directory for basic examples using a
+//! Makefile for C and C++, including static and dynamic linking in each case.
+//!
+//! If you found a nice way to integrate this crate in a build system,
+//! please consider contributing the necessary build files!
+//!
+//! # Usage
+//!
+//! You can then use the interface like this:
+//!
+//! ```C
+//! #include "rcf_cuckoofilter.h"
+//!
+//! rcf_cuckoofilter *filter = rcf_cuckoofilter_with_capacity(1000);
+//! rcf_cuckoofilter_status result;
+//! result = rcf_cuckoofilter_add(filter, 42);
+//! assert(result == RCF_OK);
+//! result = rcf_cuckoofilter_contains(filter, 42);
+//! assert(result == RCF_OK);
+//! result = rcf_cuckoofilter_delete(filter, 42);
+//! assert(result == RCF_OK);
+//! result = rcf_cuckoofilter_contains(filter, 42);
+//! assert(result == RCF_NOT_FOUND);
+//! ```
+//!
+//! # Hashing arbitrary data
+//! The interface only takes unsigned 64bit integers as `data`.
+//! If you want to insert structs or other types, search for something that hashes those to
+//! integers. Those hashes don't need to be well-distributed as they're
+//! hashed on the rust side again, so a very simple hash function is sufficient,
+//! like `std::hash` for C++ or the `__hash__` method in python.
+//! There's a good chance something like this is present in the
+//! respective standard library, for implementing hash tables and the like.
+//!
+//! In the future, the interface could accept a pointer to arbitrary memory and a size parameter,
+//! and hash that as byte array on the Rust side. But this approach is problematic if not all given
+//! bytes are the same for two equal objects.
+//!
+//! # Naming
+//! The prefix `rcf` is short for *rust cuckoo filter*.
+//! It's used for C-style namespacing to avoid name conflicts with other libraries.
+//!
+//! [cuckoofilter crate]: https://crates.io/crates/cuckoofilter
+//! [milksnake]: https://github.com/getsentry/milksnake
+
+
+extern crate cuckoofilter;
+
+use cuckoofilter::CuckooError;
+use std::collections::hash_map::DefaultHasher;
+
+/// Opaque type for a cuckoo filter using Rust's `std::collections::hash_map::DefaultHasher` as
+/// Hasher. The C ABI only supports that specific Hasher, currently.
+#[allow(non_camel_case_types)]
+pub type rcf_cuckoofilter = cuckoofilter::CuckooFilter<DefaultHasher>;
+
+#[allow(non_camel_case_types)]
+#[repr(C)]
+pub enum rcf_cuckoofilter_status {
+    RCF_OK,
+    RCF_NOT_FOUND,
+    RCF_NOT_ENOUGH_SPACE,
+}
+
+
+/// Constructs a cuckoo filter with a given max capacity.
+/// The various wrapper methods of this crate operate on the returned reference.
+/// At the end of its life, use [`rcf_cuckoofilter_free`] to free the allocated memory.
+///
+/// [`rcf_cuckoofilter_free`]: fn.rcf_cuckoofilter_free.html
+#[no_mangle]
+pub extern "C" fn rcf_cuckoofilter_with_capacity(capacity: usize) -> *mut rcf_cuckoofilter {
+    let filter = cuckoofilter::CuckooFilter::with_capacity(capacity);
+    let filter = Box::new(filter);
+    Box::into_raw(filter)
+}
+
+/// Free the given `filter`, releasing its allocated memory.
+#[no_mangle]
+pub extern "C" fn rcf_cuckoofilter_free(filter: *mut rcf_cuckoofilter) {
+    let filter = unsafe { Box::from_raw(filter) };
+    drop(filter);
+}
+
+/// Checks if the given `data` is in the `filter`.
+///
+/// Returns `rcf_cuckoofilter_status::RCF_OK` if the given `data` is in the `filter`,
+/// `rcf_cuckoofilter_status::RCF_NOT_FOUND` otherwise.
+/// Aborts if the given `filter` is a null pointer.
+#[no_mangle]
+pub extern "C" fn rcf_cuckoofilter_contains(filter: *const rcf_cuckoofilter,
+                                            data: u64)
+                                            -> rcf_cuckoofilter_status {
+    let filter = unsafe { filter.as_ref() };
+    let found = filter.expect("Given rcf_cuckoofilter* is a null pointer").contains(&data);
+    if found {
+        rcf_cuckoofilter_status::RCF_OK
+    } else {
+        rcf_cuckoofilter_status::RCF_NOT_FOUND
+    }
+}
+
+/// Adds `data` to the `filter`.
+///
+/// Returns `rcf_cuckoofilter_status::RCF_OK` if the given `data` was successfully added to the
+/// `filter`, `rcf_cuckoofilter_status::RCF_NOT_ENOUGH_SPACE` if the filter could not find a free
+/// space for it.
+/// Aborts if the given `filter` is a null pointer.
+#[no_mangle]
+pub extern "C" fn rcf_cuckoofilter_add(filter: *mut rcf_cuckoofilter,
+                                       data: u64)
+                                       -> rcf_cuckoofilter_status {
+    let filter = unsafe { filter.as_mut() };
+    match filter.expect("Given rcf_cuckoofilter* is a null pointer").add(&data) {
+        Ok(_) => rcf_cuckoofilter_status::RCF_OK,
+        Err(CuckooError::NotEnoughSpace) => rcf_cuckoofilter_status::RCF_NOT_ENOUGH_SPACE,
+    }
+}
+
+/// Returns the number of items in the `filter`.
+/// Aborts if the given `filter` is a null pointer.
+#[no_mangle]
+pub extern "C" fn rcf_cuckoofilter_len(filter: *const rcf_cuckoofilter) -> usize {
+    let filter = unsafe { filter.as_ref() };
+    filter.expect("Given rcf_cuckoofilter* is a null pointer").len()
+}
+
+/// Checks if `filter` is empty.
+/// This is equivalent to `rcf_cuckoofilter_len(filter) == 0`
+/// Aborts if the given `filter` is a null pointer.
+#[no_mangle]
+pub extern "C" fn rcf_cuckoofilter_is_empty(filter: *const rcf_cuckoofilter) -> bool {
+    let filter = unsafe { filter.as_ref() };
+    filter.expect("Given rcf_cuckoofilter* is a null pointer").is_empty()
+}
+
+/// Returns the number of bytes the `filter` occupies in memory.
+/// Aborts if the given `filter` is a null pointer.
+#[no_mangle]
+pub extern "C" fn rcf_cuckoofilter_memory_usage(filter: *const rcf_cuckoofilter) -> usize {
+    let filter = unsafe { filter.as_ref() };
+    filter.expect("Given rcf_cuckoofilter* is a null pointer").memory_usage()
+}
+
+
+/// Deletes `data` from the `filter`.
+/// Returns `rcf_cuckoofilter_status::RCF_OK` if `data` existed in the filter before,
+/// `rcf_cuckoofilter_status::RCF_NOT_FOUND` if `data` did not exist.
+/// Aborts if the given `filter` is a null pointer.
+#[no_mangle]
+pub extern "C" fn rcf_cuckoofilter_delete(filter: *mut rcf_cuckoofilter,
+                                          data: u64)
+                                          -> rcf_cuckoofilter_status {
+    let filter = unsafe { filter.as_mut() };
+    let found = filter.expect("Given rcf_cuckoofilter* is a null pointer").delete(&data);
+    if found {
+        rcf_cuckoofilter_status::RCF_OK
+    } else {
+        rcf_cuckoofilter_status::RCF_NOT_FOUND
+    }
+}

--- a/cabi/tests/Makefile
+++ b/cabi/tests/Makefile
@@ -1,0 +1,30 @@
+INCLUDE = ../target/include
+LIB = ../target/release
+CFLAGS = -I$(INCLUDE)
+BUILDDIR = build
+
+LDFLAGS_STATIC = -L$(LIB) -l:libcuckoofilter_cabi.a -ldl -lpthread
+LDFLAGS_DYNAMIC = -L$(LIB) -Wl,-rpath=$(LIB) -lcuckoofilter_cabi
+
+
+tests: basic_operations_static basic_operations_dynamic basic_operations_cpp_static basic_operations_cpp_dynamic
+
+
+basic_operations_static: basic_operations.c
+	mkdir -p $(BUILDDIR)
+	$(CC) $(CFLAGS) -o $(BUILDDIR)/$@ $^ $(LDFLAGS_STATIC)
+
+basic_operations_dynamic: basic_operations.c
+	mkdir -p $(BUILDDIR)
+	$(CC) $(CFLAGS) -o $(BUILDDIR)/$@ $^ $(LDFLAGS_DYNAMIC)
+
+basic_operations_cpp_static: basic_operations.c
+	mkdir -p $(BUILDDIR)
+	$(CXX) $(CFLAGS) -o $(BUILDDIR)/$@ $^ $(LDFLAGS_STATIC)
+
+basic_operations_cpp_dynamic: basic_operations.c
+	mkdir -p $(BUILDDIR)
+	$(CXX) $(CFLAGS) -o $(BUILDDIR)/$@ $^ $(LDFLAGS_DYNAMIC)
+
+clean:
+	rm basic_operations_static basic_operations_dynamic basic_operations_cpp_static basic_operations_cpp_dynamic

--- a/cabi/tests/basic_operations.c
+++ b/cabi/tests/basic_operations.c
@@ -1,0 +1,38 @@
+#include <stdio.h>
+#include <assert.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "rcf_cuckoofilter.h"
+#ifdef __cplusplus
+}
+#endif
+
+int main(int argc, char **argv) {
+    rcf_cuckoofilter *filter = rcf_cuckoofilter_with_capacity(1024);
+    rcf_cuckoofilter_status status;
+
+    status = rcf_cuckoofilter_add(filter, 42);
+    assert(status == RCF_OK);
+    printf("added 42: %d\n", status == RCF_OK);
+
+    status = rcf_cuckoofilter_contains(filter, 42);
+    assert(status == RCF_OK);
+    printf("contains 42: %d\n", status == RCF_OK);
+
+    status = rcf_cuckoofilter_contains(filter, 4711);
+    assert(status == RCF_NOT_FOUND);
+    printf("contains 4711: %d\n", status == RCF_OK);
+
+    status = rcf_cuckoofilter_delete(filter, 42);
+    assert(status == RCF_OK);
+    printf("deleted 42: %d\n", status == RCF_OK);
+
+    status = rcf_cuckoofilter_contains(filter, 42);
+    assert(status == RCF_NOT_FOUND);
+    printf("contains 42: %d\n", status == RCF_OK);
+
+    rcf_cuckoofilter_free(filter);
+
+    return 0;
+}


### PR DESCRIPTION
to make rust-cuckoofilter embeddable in other languages via FFI.

I added the bindings as a separate crate in a subfolder, for separation and in particular to avoid that normal rust users need to build cbindgen, serde and other compiletime-intensive syntax / macro stuff.

@seiflotfy what do you think?

After this, everything I like to do for now is in, and I'd like to release v0.4.0 then if that's ok with you.

**NOTE**: Marking WIP, as I suddenly can't get linking to work anymore, but that might be a problem of the external project's cmake files.