### PR TITLE
Implement import/export features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [v0.4.0] - Unreleased
 ### Added
-- `ExportedCuckooFilter` adds the ability to serialize the memory map of a `CuckooFilter`; reducing communication overhead between nodes for example, or the ability to store the current state on disk for retrieval at a later time.
+- `ExportedCuckooFilter` adds the ability to serialize the memory map of a `CuckooFilter` via Serde; reducing communication overhead between nodes for example, or the ability to store the current state on disk for retrieval at a later time.
 ### Changed
 - add() now returns Result<(), CuckooError> instead of a bool, and returns a NotEnoughSpaceError instead of panicking
   when insertion fails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [v0.4.0] - Unreleased
 ### Added
+- `ExportedCuckooFilter` adds the ability to serialize the memory map of a `CuckooFilter`; reducing communication overhead between nodes for example, or the ability to store the current state on disk for retrieval at a later time.
 ### Changed
 - add() now returns Result<(), CuckooError> instead of a bool, and returns a NotEnoughSpaceError instead of panicking
   when insertion fails.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,11 @@ dev = ["clippy"]
 [dependencies]
 byteorder = "1.2"
 rand = "0.3"
+serde = "1.0"
+serde_derive = "1.0"
 clippy = {version = "0.0.77", optional = true}
 fnv = {version = "1.0.2", optional = true}
 farmhash = {version = "1.1", optional = true}
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -88,7 +88,7 @@ impl Bucket {
         self.buffer
             .iter()
             .flat_map(|f| f.data.into_iter())
-            .map(|&f| f)
+            .cloned()
             .collect()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,6 +267,15 @@ pub struct ExportedCuckooFilter {
 impl<H> From<ExportedCuckooFilter> for CuckooFilter<H> {
     /// Converts a simplified representation of a filter used for export to a
     /// fully functioning version.
+    ///
+    /// # Contents
+    ///
+    /// * `values` - A serialized version of the `CuckooFilter`'s memory, where the
+    /// fingerprints in each bucket are chained one after another, then in turn all
+    /// buckets are chained together.
+    /// * `length` - The number of valid fingerprints inside the `CuckooFilter`.
+    /// This value is used as a time saving method, otherwise all fingerprints
+    /// would need to be checked for equivalence against the null pattern.
     fn from(exported: ExportedCuckooFilter) -> CuckooFilter<H> {
         // Assumes that the `BUCKET_SIZE` and `FINGERPRINT_SIZE` constants do not change.
         CuckooFilter {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use std::hash::{Hasher, Hash};
+use std::hash::{Hash, Hasher};
 use byteorder::{BigEndian, WriteBytesExt};
 use bucket::{Fingerprint, FINGERPRINT_SIZE};
 
@@ -60,7 +60,11 @@ impl FaI {
     }
 
     pub fn random_index<R: ::rand::Rng>(&self, r: &mut R) -> usize {
-        if r.gen() { self.i1 } else { self.i2 }
+        if r.gen() {
+            self.i1
+        } else {
+            self.i2
+        }
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 use std::hash::{Hasher, Hash};
-use ::byteorder::{BigEndian, WriteBytesExt};
-use ::bucket::{Fingerprint, FINGERPRINT_SIZE};
+use byteorder::{BigEndian, WriteBytesExt};
+use bucket::{Fingerprint, FINGERPRINT_SIZE};
 
 // A struct combining *F*ingerprint *a*nd *I*ndexes,
 // to have a return type with named fields
@@ -60,11 +60,7 @@ impl FaI {
     }
 
     pub fn random_index<R: ::rand::Rng>(&self, r: &mut R) -> usize {
-        if r.gen() {
-            self.i1
-        } else {
-            self.i2
-        }
+        if r.gen() { self.i1 } else { self.i2 }
     }
 }
 

--- a/tests/interop.rs
+++ b/tests/interop.rs
@@ -1,0 +1,35 @@
+extern crate cuckoofilter;
+use cuckoofilter::CuckooFilter;
+use std::collections::hash_map::DefaultHasher;
+
+#[test]
+fn interoperability() {
+    let total_items = 1_000_000;
+
+    let mut filter = CuckooFilter::<DefaultHasher>::with_capacity(total_items);
+
+    let mut num_inserted: u64 = 0;
+    // Fit as many values in as possible, count how many made it in.
+    for i in 0..total_items {
+        match filter.add(&i) {
+            Ok(_) => num_inserted += 1,
+            Err(_) => break,
+        }
+    }
+
+    // Export the fingerprint data stored in the filter,
+    // along with the filter's current length.
+    let store: Vec<u8> = filter.export();
+    let length = filter.len();
+
+    // Create a new filter using the `recover` method and the values previously exported.
+    let recovered_filter = CuckooFilter::<DefaultHasher>::recover(store, length);
+
+    // The range 0..num_inserted are all known to be in the filter.
+    // The filters shouldn't return false negatives, and therefore they should all be contained.
+    // Both filters should also be identical.
+    for i in 0..num_inserted {
+        assert!(filter.contains(&i));
+        assert!(recovered_filter.contains(&i));
+    }
+}

--- a/tests/interop.rs
+++ b/tests/interop.rs
@@ -1,5 +1,7 @@
 extern crate cuckoofilter;
-use cuckoofilter::CuckooFilter;
+extern crate serde_json;
+
+use cuckoofilter::{CuckooFilter, ExportedCuckooFilter};
 use std::collections::hash_map::DefaultHasher;
 
 #[test]
@@ -19,17 +21,47 @@ fn interoperability() {
 
     // Export the fingerprint data stored in the filter,
     // along with the filter's current length.
-    let store: Vec<u8> = filter.export();
-    let length = filter.len();
+    let store: ExportedCuckooFilter = filter.export();
 
     // Create a new filter using the `recover` method and the values previously exported.
-    let recovered_filter = CuckooFilter::<DefaultHasher>::recover(store, length);
+    let recovered_filter = CuckooFilter::<DefaultHasher>::from(store);
 
     // The range 0..num_inserted are all known to be in the filter.
     // The filters shouldn't return false negatives, and therefore they should all be contained.
     // Both filters should also be identical.
     for i in 0..num_inserted {
         assert!(filter.contains(&i));
+        assert!(recovered_filter.contains(&i));
+    }
+
+    // The range total_items..(2 * total_items) are all known *not* to be in the filter.
+    // Every element for which the filter claims that it is contained is therefore a false positive, and both the original filter and recovered filter should exhibit the same false positive behaviour.
+    for i in total_items..(2 * total_items) {
+        assert_eq!(filter.contains(&i), recovered_filter.contains(&i));
+    }
+}
+
+#[test]
+fn serialization() {
+    // Just a small filter to test serialization.
+    let mut filter = CuckooFilter::<DefaultHasher>::with_capacity(100);
+
+    // Fill a few values.
+    for i in 0..50 {
+        filter.add(&i).unwrap();
+    }
+    // export data.
+    let store: ExportedCuckooFilter = filter.export();
+
+    // serialize using json (for example, any serde format can be used).
+    let saved_json = serde_json::to_string(&store).unwrap();
+
+    // create a new filter from the json string.
+    let restore_json: ExportedCuckooFilter = serde_json::from_str(&saved_json).unwrap();
+    let recovered_filter = CuckooFilter::<DefaultHasher>::from(restore_json);
+
+    // Check our values exist within the reconstructed filter.
+    for i in 0..50 {
         assert!(recovered_filter.contains(&i));
     }
 }


### PR DESCRIPTION
Closes #28 by introducing `export`, which collects all fingerprint data into a simple `Vec<u8>` for easy storage into a file or database.

Using such data, along with the length of the filter (from `len`) we can later reconstruct the filter by importing the stored data through `recover`.

(Some minor changes also introduced via rust-fmt)