### PR TITLE
Remove my name from authors and add "cuckoofilter developers"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "cuckoofilter"
 version = "0.4.0"
-authors = ["Seif Lotfy <seif.lotfy@gmail.com>", "Lukas Kalbertodt <lukas.kalbertodt@gmail.com>", "Florian Jacob <accounts+git@florianjacob.de>"]
+authors = [
+  "Seif Lotfy <seif.lotfy@gmail.com>", 
+  "Florian Jacob <accounts+git@florianjacob.de>", 
+  "The cuckoofilter contributors",
+]
 
 # A short blurb about the package. This is not rendered in any format when
 # uploaded to crates.io (aka this is not markdown)


### PR DESCRIPTION
I only contributed a cleanup PR. Very kind to include me in the author list, but I think I shouldn't be in there. Instead, I added "The cuckoofilter developers" which is a common solution to include "all other developers". See for example [vulkano](https://crates.io/crates/vulkano).