### PR TITLE
Avoid re-hashing during test_and_add

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde_support = ["serde", "serde_derive", "serde_bytes"]
 
 [dependencies]
 byteorder = "1.4.3"
-rand = "0.8.5"
+rand = "0.9.2"
 serde = { version = "1.0.137", optional = true }
 serde_derive = { version = "1.0.137", optional = true }
 serde_bytes = { version = "0.11.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde_support = ["serde", "serde_derive", "serde_bytes"]
 
 [dependencies]
 byteorder = "1.4.3"
-rand = "0.8.5"
+rand = "0.10.1"
 serde = { version = "1.0.137", optional = true }
 serde_derive = { version = "1.0.137", optional = true }
 serde_bytes = { version = "0.11.6", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,13 +260,13 @@ where
             return Ok(());
         }
         let len = self.buckets.len();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut i = fai.random_index(&mut rng);
         let mut fp = fai.fp;
         for _ in 0..MAX_REBUCKET {
             let other_fp;
             {
-                let loc = &mut self.buckets[i % len].buffer[rng.gen_range(0..BUCKET_SIZE)];
+                let loc = &mut self.buckets[i % len].buffer[rng.random_range(0..BUCKET_SIZE)];
                 other_fp = *loc;
                 *loc = fp;
                 i = get_alt_index::<H>(other_fp, i);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,6 @@ use std::collections::hash_map::DefaultHasher;
 use std::error::Error as StdError;
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::iter::repeat;
 use std::marker::PhantomData;
 use std::mem;
 
@@ -136,10 +135,7 @@ where
         let capacity = cmp::max(1, cap.next_power_of_two() / BUCKET_SIZE);
 
         Self {
-            buckets: repeat(Bucket::new())
-                .take(capacity)
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
+            buckets: vec![Bucket::new(); capacity].into_boxed_slice(),
             len: 0,
             _hasher: PhantomData,
         }
@@ -303,11 +299,11 @@ impl<H> From<ExportedCuckooFilter> for CuckooFilter<H> {
     /// # Contents
     ///
     /// * `values` - A serialized version of the `CuckooFilter`'s memory, where the
-    /// fingerprints in each bucket are chained one after another, then in turn all
-    /// buckets are chained together.
+    ///   fingerprints in each bucket are chained one after another, then in turn all
+    ///   buckets are chained together.
     /// * `length` - The number of valid fingerprints inside the `CuckooFilter`.
-    /// This value is used as a time saving method, otherwise all fingerprints
-    /// would need to be checked for equivalence against the null pattern.
+    ///   This value is used as a time saving method, otherwise all fingerprints
+    ///   would need to be checked for equivalence against the null pattern.
     fn from(exported: ExportedCuckooFilter) -> Self {
         // Assumes that the `BUCKET_SIZE` and `FINGERPRINT_SIZE` constants do not change.
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ use std::iter::repeat;
 use std::marker::PhantomData;
 use std::mem;
 
-use rand::Rng;
+use rand::RngExt;
 #[cfg(feature = "serde_support")]
 use serde_derive::{Deserialize, Serialize};
 
@@ -260,13 +260,13 @@ where
             return Ok(());
         }
         let len = self.buckets.len();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut i = fai.random_index(&mut rng);
         let mut fp = fai.fp;
         for _ in 0..MAX_REBUCKET {
             let other_fp;
             {
-                let loc = &mut self.buckets[i % len].buffer[rng.gen_range(0..BUCKET_SIZE)];
+                let loc = &mut self.buckets[i % len].buffer[rng.random_range(0..BUCKET_SIZE)];
                 other_fp = *loc;
                 *loc = fp;
                 i = get_alt_index::<H>(other_fp, i);

--- a/src/util.rs
+++ b/src/util.rs
@@ -26,7 +26,7 @@ fn get_hash<T: ?Sized + Hash, H: Hasher + Default>(data: &T) -> (u32, u32) {
 pub fn get_alt_index<H: Hasher + Default>(fp: Fingerprint, i: usize) -> usize {
     let (_, index_hash) = get_hash::<_, H>(&fp.data);
     let alt_i = index_hash as usize;
-    (i ^ alt_i) as usize
+    i ^ alt_i
 }
 
 impl FaI {

--- a/src/util.rs
+++ b/src/util.rs
@@ -58,7 +58,7 @@ impl FaI {
     }
 
     pub fn random_index<R: ::rand::Rng>(&self, r: &mut R) -> usize {
-        if r.gen() {
+        if r.random() {
             self.i1
         } else {
             self.i2

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,6 +3,7 @@ use crate::bucket::{Fingerprint, FINGERPRINT_SIZE};
 use std::hash::{Hash, Hasher};
 
 use byteorder::{BigEndian, WriteBytesExt};
+use rand::RngExt;
 
 // A struct combining *F*ingerprint *a*nd *I*ndexes,
 // to have a return type with named fields
@@ -58,7 +59,7 @@ impl FaI {
     }
 
     pub fn random_index<R: ::rand::Rng>(&self, r: &mut R) -> usize {
-        if r.gen() {
+        if r.random() {
             self.i1
         } else {
             self.i2

--- a/src/util.rs
+++ b/src/util.rs
@@ -27,7 +27,7 @@ fn get_hash<T: ?Sized + Hash, H: Hasher + Default>(data: &T) -> (u32, u32) {
 pub fn get_alt_index<H: Hasher + Default>(fp: Fingerprint, i: usize) -> usize {
     let (_, index_hash) = get_hash::<_, H>(&fp.data);
     let alt_i = index_hash as usize;
-    (i ^ alt_i) as usize
+    i ^ alt_i
 }
 
 impl FaI {


### PR DESCRIPTION
Prior to this PR, when doing a `test_and_add`, the cuckoo filter would hash the data twice to get the fingerprint and indeces. It doesn't seem like this is necessary as hashes should be idempotent so this PR changes the function to only hash once and then send the `FaI` to both the internals of the test and add function. 

Also, some general maintenance:
* Upgrade to `rand` to 0.9:  it's a fairly used crate so it'd help others that already have the `0.9` version somewhere in their dep chain. 
* fix clippy warnings on latest Rust. 